### PR TITLE
Add test to check Icinga 2 is installed

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,6 +1,10 @@
 ---
 - name: Converge
   hosts: all
+
+  roles:
+    - role: ansible-role-icinga2
+
   pre_tasks:
     - name: Install required packages
       apt:
@@ -10,5 +14,11 @@
         update_cache: true
       when: ansible_os_family == 'Debian'
       changed_when: false
-  roles:
-    - role: ansible-role-icinga2
+
+  post_tasks:
+    - name: Ensure Icinga 2 is installed
+      stat:
+        path: /usr/sbin/icinga2
+      register: result
+      changed_when: false
+      failed_when: result.stat.isreg is not defined or not result.stat.isreg


### PR DESCRIPTION
This commit adds some tests to check that Icinga 2 is installed, started and enabled.