### PR TITLE
Fix tests on Debian 9

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -14,6 +14,13 @@
         update_cache: true
       when: ansible_os_family == 'Debian'
       changed_when: false
+    - name: Install Debian Backports repository
+      apt_repository:
+        repo: deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main
+        state: present
+        update_cache: yes
+      when: ansible_os_family == 'Debian' and ansible_distribution_release == 'stretch'
+      changed_when: false
 
   post_tasks:
     - name: Ensure Icinga 2 is installed


### PR DESCRIPTION
Installation of Icinga 2.11+ on Debian Stretch requires the backports repository to be enabled, as per Icinga/icinga-packaging#150.